### PR TITLE
Utilisation de l'ancienne bdd

### DIFF
--- a/affichage/affichage_table.php
+++ b/affichage/affichage_table.php
@@ -1,0 +1,56 @@
+<?php
+include("../header.html");
+?>
+
+<header>
+	<script type="text/javascript">
+
+		$(document).ready(function(){
+			//LES MODELES//////////////////////////////////////////
+			var modelJTable = $("<div class='tables text-center'>");
+			var modelJLabel = $("<div class='label label-default'>");
+			var modelJP = $("<p>");
+			///////////////////////////////////////////////////////
+
+			$.getJSON("../data.php", {
+				action : "getTables",
+				bdd : 1},
+				function(oRep){
+					console.log(oRep);
+					for(var i=0; i<oRep.boards.length; i++){
+						var meta = oRep.boards[i];
+						//CREATION DU LABEL////////////////////////////////////////////////////
+						var unP = modelJP.clone().html("<b>"+meta.label+"</b>");
+						var unLabel = modelJLabel.clone(true).append(unP);
+						///////////////////////////////////////////////////////////////////////
+						var uneTable = modelJTable.clone(true).append(unLabel)
+							.data("label", meta.label); //On stocke le label dans le div.
+						$("#content").append(uneTable);
+					}
+				}
+
+			)
+
+		});
+
+	</script>
+
+	<style>
+		#content{
+			background-color: lightblue;
+			display: flex;
+		}
+		.tables{
+			background-color: orange;
+			width: 300px;
+			height: 450px;
+			border: black 2px solid;
+			margin: 20px;
+		}
+	</style>
+</header>
+
+<body>
+	<div class="container" id="content">
+	</div>
+</body>

--- a/bdd_dblock.sql
+++ b/bdd_dblock.sql
@@ -1,0 +1,118 @@
+-- phpMyAdmin SQL Dump
+-- version 4.8.3
+-- https://www.phpmyadmin.net/
+--
+-- Hôte : 127.0.0.1:3306
+-- Généré le :  mer. 06 fév. 2019 à 09:44
+-- Version du serveur :  5.7.23
+-- Version de PHP :  7.2.10
+
+SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
+SET AUTOCOMMIT = 0;
+START TRANSACTION;
+SET time_zone = "+00:00";
+
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
+
+--
+-- Base de données :  `bdd_dblock`
+--
+
+-- --------------------------------------------------------
+
+--
+-- Structure de la table `bdd`
+--
+
+DROP TABLE IF EXISTS `bdd`;
+CREATE TABLE IF NOT EXISTS `bdd` (
+  `id` int(11) DEFAULT NULL,
+  `nom` varchar(30) DEFAULT NULL,
+  `description` varchar(100) DEFAULT NULL,
+  `idCreateur` int(11) DEFAULT NULL,
+  KEY `idCreateur` (`idCreateur`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
+-- --------------------------------------------------------
+
+--
+-- Structure de la table `colonne`
+--
+
+DROP TABLE IF EXISTS `colonne`;
+CREATE TABLE IF NOT EXISTS `colonne` (
+  `id` int(11) DEFAULT NULL,
+  `label` varchar(20) DEFAULT NULL,
+  `idTab` int(11) DEFAULT NULL,
+  KEY `idTab` (`idTab`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
+-- --------------------------------------------------------
+
+--
+-- Structure de la table `data`
+--
+
+DROP TABLE IF EXISTS `data`;
+CREATE TABLE IF NOT EXISTS `data` (
+  `id` int(11) DEFAULT NULL,
+  `valInt` int(11) DEFAULT NULL,
+  `valChar` varchar(1000) DEFAULT NULL,
+  `idColonne` int(11) DEFAULT NULL,
+  KEY `idColonne` (`idColonne`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
+-- --------------------------------------------------------
+
+--
+-- Structure de la table `liste_user`
+--
+
+DROP TABLE IF EXISTS `liste_user`;
+CREATE TABLE IF NOT EXISTS `liste_user` (
+  `idBdd` int(11) DEFAULT NULL,
+  `idUser` int(11) DEFAULT NULL,
+  KEY `idBdd` (`idBdd`),
+  KEY `idUser` (`idUser`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
+-- --------------------------------------------------------
+
+--
+-- Structure de la table `tab`
+--
+
+DROP TABLE IF EXISTS `tab`;
+CREATE TABLE IF NOT EXISTS `tab` (
+  `id` int(11) DEFAULT NULL,
+  `label` varchar(20) DEFAULT NULL,
+  `idBdd` int(11) DEFAULT NULL,
+  `idUser` int(11) DEFAULT NULL,
+  KEY `idBdd` (`idBdd`),
+  KEY `idUser` (`idUser`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
+-- --------------------------------------------------------
+
+--
+-- Structure de la table `user`
+--
+
+DROP TABLE IF EXISTS `user`;
+CREATE TABLE IF NOT EXISTS `user` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `prenom` varchar(30) NOT NULL,
+  `nom` varchar(30) NOT NULL,
+  `grade` int(11) NOT NULL DEFAULT '0',
+  `password` varchar(30) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+COMMIT;
+
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;

--- a/data.php
+++ b/data.php
@@ -47,7 +47,7 @@ session_start();
 						$data["feedback"] = "Entrez identifiant,passe (eg 'user','user')";
 
 					} else {
-						$data["feedback"] = "Utilisateur connect�";
+						$data["feedback"] = "Utilisateur connecte";
 						$data["connecte"] = true;
 						header('Location:affichage/test.php');
 					}
@@ -82,8 +82,9 @@ session_start();
 				break;
 
 
-				case 'getTables' : 
-					$data["boards"] = listerTables();
+				case 'getTables' :
+					$bdd = valider('bdd');
+					$data["boards"] = listerTables($bdd);
 				break;
 
 				case 'majTable' : 

--- a/libs/config.php
+++ b/libs/config.php
@@ -3,6 +3,6 @@
 $BDD_host="localhost";
 $BDD_user="root";
 $BDD_password="";
-$BDD_base="dblock2";
+$BDD_base="dblock";
 
 ?>

--- a/libs/maLibSecurisation.php
+++ b/libs/maLibSecurisation.php
@@ -21,7 +21,7 @@ include_once "bdd.php";	// Car on utilise la fonction connecterUtilisateur()
 function verifUser($login,$password)
 {
 	// NE PAS ETRE UN LOSER
-	$sql = "SELECT id, identifiant FROM users WHERE identifiant='$login' AND password='$password' ";
+	$sql = "SELECT id, identifiant FROM user WHERE identifiant='$login' AND password='$password' ";
 	$rs = SQLSelect($sql);
 	if ($rs)
 	{


### PR DESCRIPTION
On réutilise l'ancienne BDD parce que toutes les liaisons PRIMARY KEY et FOREIGN KEY sont faites.
Si ça ne marche pas vérifiez bien votre **config.php**. Je vous conseille d’appeler votre bdd "dblock". 
Normalement **data.php** fonctionne correctement, sinon n'oubliez pas de créer une "Issues".
@LucmanX76 @ClementBrd 